### PR TITLE
Make building of `ayatana-indicator-loader3` optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,12 @@ AS_IF([test "x$enable_deprecations" = xno],
   [CFLAGS="$CFLAGS -DG_DISABLE_DEPRECATED -DGDK_DISABLE_DEPRECATED -DGDK_PIXBUF_DISABLE_DEPRECATED -DGTK_DISABLE_DEPRECATED -DGSEAL_ENABLE -DGTK_DISABLE_SINGLE_INCLUDES"]
 )
 
+AC_ARG_ENABLE([ido],
+  [AS_HELP_STRING([--enable-ido],
+    [enable indicator widget loader @<:@default=yes@:>@])],
+  [],
+  [enable_ido=yes])
+
 ##############################
 # Dependencies
 ##############################
@@ -62,6 +68,7 @@ GTK3_REQUIRED_VERSION=3.6
 GIO_UNIX_REQUIRED_VERSION=2.37
 IDO_REQUIRED_VERSION=0.4.0
 
+
 AC_ARG_WITH([gtk],
   [AS_HELP_STRING([--with-gtk],
     [Which version of gtk to use @<:@default=3@:>@])],
@@ -70,8 +77,10 @@ AC_ARG_WITH([gtk],
 AS_IF([test "x$with_gtk" = x3],
         [PKG_CHECK_MODULES(LIBINDICATOR,  gtk+-3.0 >= $GTK3_REQUIRED_VERSION
                                           gmodule-2.0
-                                          gio-unix-2.0 >= $GIO_UNIX_REQUIRED_VERSION
-                                          libayatana-ido3-0.4 >= $IDO_REQUIRED_VERSION)
+                                          gio-unix-2.0 >= $GIO_UNIX_REQUIRED_VERSION)
+         AS_IF([test "x$enable_ido" = xyes], [
+           PKG_CHECK_MODULES(LIBINDICATOR_IDO, libayatana-ido3-0.4 >= $IDO_REQUIRED_VERSION)
+         ])
         ],
       [test "x$with_gtk" = x2],
         [PKG_CHECK_MODULES(LIBINDICATOR,  gtk+-2.0 >= $GTK_REQUIRED_VERSION
@@ -80,7 +89,9 @@ AS_IF([test "x$with_gtk" = x3],
         ],
       [AC_MSG_FAILURE([Value for --with-gtk was neither 2 nor 3])]
 )
+
 AM_CONDITIONAL(USE_GTK3, [test "x$with_gtk" = x3])
+AM_CONDITIONAL(USE_IDO, [test "$enable_ido" = "yes"])
 
 LT_LIB_M
 AC_SUBST(LIBM)
@@ -200,6 +211,7 @@ Libindicator Configuration:
 	Prefix:                 $prefix
 	GTK+ Version:           $with_gtk
 	
+	Enable IDO loader:      $enable_ido
 	Enable tests:           $enable_tests
 	Enable debugging:       $enable_debug
 	Coverage reporting:     $use_gcov

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,7 +1,9 @@
+if USE_IDO
 if USE_GTK3
 INDICATOR_LIB = -layatana-indicator3
 libexec_PROGRAMS = ayatana-indicator-loader3
 VER=3
+endif
 endif
 
 
@@ -14,11 +16,13 @@ ayatana_indicator_loader_SOURCES = \
 
 ayatana_indicator_loader_CFLAGS = \
 	-Wall -Werror \
-	$(LIBINDICATOR_CFLAGS) -I$(top_srcdir) \
+	$(LIBINDICATOR_CFLAGS) \
+	$(LIBINDICATOR_IDO_CFLAGS) -I$(top_srcdir) \
 	-DBUILD_DIR="\"$(builddir)\""
 
 ayatana_indicator_loader_LDADD = \
 	$(LIBINDICATOR_LIBS) \
+	$(LIBINDICATOR_IDO_LIBS) \
 	-L$(top_builddir)/libayatana-indicator/.libs \
 	$(INDICATOR_LIB)
 


### PR DESCRIPTION
Adds `--disable-ido` to prevent building of the `ayatana-indicator-loader3` which requires `libayatana-ido3-0.4`.

The use-case for this being that, in my case, I embed `libayatana-appindicator3` into a Flatpak runtime for an app that simply wants to display a systray icon while also happening to use GTK+3 for its frontend. There is no need for building libido in this case.