### PR TITLE
Use indicators.target as the systemd lifecycle unit

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,5 +1,5 @@
 #if defined(HAVE_SYSTEMD)
-systemd_DATA = ayatana-indicators-pre.target
+systemd_DATA = ayatana-indicators.target
 systemddir = $(SYSTEMD_USERDIR)
 EXTRA_DIST = $(systemd_DATA)
 #endif

--- a/data/ayatana-indicators.target
+++ b/data/ayatana-indicators.target
@@ -1,2 +1,7 @@
 [Unit]
 Description=Target representing the lifecycle of the Ayatana Indicators. Each indicator should be bound to it in its individual service file.
+PartOf=graphical-session.target
+
+[Install]
+# Old name for this target, kept for compatibility
+Alias=ayatana-indicators-pre.target

--- a/debian/ayatana-indicator-common.links
+++ b/debian/ayatana-indicator-common.links
@@ -1,0 +1,2 @@
+# Because dh-systemd does not yet support user units, we manually make the Alias link
+/usr/lib/systemd/user/ayatana-indicators.target /usr/lib/systemd/user/ayatana-indicators-pre.target


### PR DESCRIPTION
Use indicators.target as the systemd lifecycle unit, not indicators-pre.target.

Patch from:
https://code.launchpad.net/~mterry/libindicator/rename-unit/+merge/321556

This is a series for patches touching all indicators. 