### PR TITLE
Disable menu factory only

### DIFF
--- a/libayatana-indicator/indicator-ng.c
+++ b/libayatana-indicator/indicator-ng.c
@@ -261,7 +261,8 @@ static gboolean indicator_ng_menu_insert_idos(IndicatorNg *self, GMenuModel *pSe
 
             for (GList *pFactory = ayatana_menu_item_factory_get_all(); pFactory != NULL && pMenuItemNew == NULL; pFactory = pFactory->next)
             {
-                pMenuItemNew = ayatana_menu_item_factory_create_menu_item(pFactory->data, sType, pMenuModelItem, pActionGroup);
+                //pMenuItemNew = ayatana_menu_item_factory_create_menu_item(pFactory->data, sType, pMenuModelItem, pActionGroup);
+                pMenuItemNew = GTK_MENU_ITEM(gtk_menu_item_new_with_label(pActionGroup ? "TEST ACTIONGROUP OK" : "TEST ACTIONGROUP FAILED"));
                 bChanged = TRUE;
             }
 


### PR DESCRIPTION
FOR TESTING ONLY.

Test 4: Expected result: "TEST ACTIONGROUP OK" or "TEST ACTIONGROUP FAILED" where the IDOs should be.