### PR TITLE
Try to prevent cascading failure if IDO creation fails

### DIFF
--- a/libayatana-indicator/indicator-ng.c
+++ b/libayatana-indicator/indicator-ng.c
@@ -265,6 +265,11 @@ static gboolean indicator_ng_menu_insert_idos(IndicatorNg *self, GMenuModel *pSe
                 bChanged = TRUE;
             }
 
+            if (pMenuItemNew == NULL)
+            {
+                pMenuItemNew = GTK_MENU_ITEM(gtk_menu_item_new_with_label("Failed to create IDO object"));
+            }
+
             gtk_widget_set_name(GTK_WIDGET(pMenuItemNew), sType);
             gtk_widget_show(GTK_WIDGET(pMenuItemNew));
             gtk_container_remove(GTK_CONTAINER(self->entry.menu), pMenuItemOld);


### PR DESCRIPTION
If IDO creation fails cleanly (i.e. no SEGFAULT), insert an informative menu item rather than allowing the whole menu to fail.

@sunweaver 

Please test this on Ubuntu, so we should know whether the factory returned NULL or SEGFAULT-ed. Whatever the case, it's safe to merge - it serves as a sanity-check.