### PR TITLE
src/{CMakeLists.txt,indicator.symbols}: Don't export private symbols. Immitate symbol exports as previously done with libtool.

### DIFF
--- a/debian/libayatana-indicator3-7.symbols
+++ b/debian/libayatana-indicator3-7.symbols
@@ -2,11 +2,6 @@ libayatana-indicator3.so.7 libayatana-indicator3-7 #MINVER#
 *Build-Depends-Package: libayatana-indicator3-dev
  ICON_SIZE@Base 0.6.0
  INDICATOR_NAMES_DATA@Base 0.6.0
- _indicator_object_marshal_VOID__POINTER_BOOLEAN@Base 0.8.5
- _indicator_object_marshal_VOID__POINTER_UINT@Base 0.8.5
- _indicator_object_marshal_VOID__POINTER_UINT_ENUM@Base 0.8.5
- _indicator_object_marshal_VOID__POINTER_UINT_UINT@Base 0.8.5
- _indicator_service@Base 0.8.5
 #MISSING: 0.8.0# ayatana_menu_item_factory_create_menu_item@Base 0.7.0
 #MISSING: 0.8.0# ayatana_menu_item_factory_get_all@Base 0.7.0
 #MISSING: 0.8.0# ayatana_menu_item_factory_get_type@Base 0.7.0

--- a/debian/libayatana-indicator7.symbols
+++ b/debian/libayatana-indicator7.symbols
@@ -2,11 +2,6 @@ libayatana-indicator.so.7 libayatana-indicator7 #MINVER#
 *Build-Depends-Package: libayatana-indicator-dev
  ICON_SIZE@Base 0.6.0
  INDICATOR_NAMES_DATA@Base 0.6.0
- _indicator_object_marshal_VOID__POINTER_BOOLEAN@Base 0.8.5
- _indicator_object_marshal_VOID__POINTER_UINT@Base 0.8.5
- _indicator_object_marshal_VOID__POINTER_UINT_ENUM@Base 0.8.5
- _indicator_object_marshal_VOID__POINTER_UINT_UINT@Base 0.8.5
- _indicator_service@Base 0.8.5
  indicator_desktop_shortcuts_get_nicks@Base 0.6.0
  indicator_desktop_shortcuts_get_type@Base 0.6.0
  indicator_desktop_shortcuts_new@Base 0.6.0

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,6 +140,7 @@ target_compile_definitions("${ayatana_indicator_gtkver}" PUBLIC DG_LOG_DOMAIN="l
 target_include_directories("${ayatana_indicator_gtkver}" PUBLIC ${PROJECT_DEPS_INCLUDE_DIRS})
 target_include_directories("${ayatana_indicator_gtkver}" PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories("${ayatana_indicator_gtkver}" PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+target_link_options("${ayatana_indicator_gtkver}" PRIVATE "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/indicator.symbols")
 target_link_libraries("${ayatana_indicator_gtkver}" ${PROJECT_DEPS_LIBRARIES} ${EXTRA_LIBS})
 add_dependencies("${ayatana_indicator_gtkver}" "src-generated")
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/lib${ayatana_indicator_gtkver}.so" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}")

--- a/src/indicator.symbols
+++ b/src/indicator.symbols
@@ -1,0 +1,6 @@
+{
+    global: indicator_*;
+            INDICATOR_*;
+            ICON_SIZE*;
+    local:  _indicator_*;
+};


### PR DESCRIPTION
Fixes https://github.com/AyatanaIndicators/libayatana-indicator/issues/59