### PR TITLE
Remove unnecessary gio/gdesktopappinfo.h include

### DIFF
--- a/src/indicator-desktop-shortcuts.c
+++ b/src/indicator-desktop-shortcuts.c
@@ -25,7 +25,6 @@ License along with this library. If not, see
 #include "config.h"
 #endif
 
-#include <gio/gdesktopappinfo.h>
 #include "indicator-desktop-shortcuts.h"
 
 #define ACTIONS_KEY               "Actions"


### PR DESCRIPTION
This was introduced in 5d7fbff4c97779922efe03268deaf669a5a4eaa8 but the code using it was removed in 0312ffa2d621b398462659429a7c2b778da93ca8 so it is not necessary anymore now. Moreover, this header is not available when glib is compiled with cocoa so it would break the build in such cases.